### PR TITLE
Validate presence and content type of attachment

### DIFF
--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -19,6 +19,7 @@ class UploadController < ApplicationController
       @dataset.create_import_job
       redirect_to :controller => 'after_upload', :import_job_id => @dataset.import_job.id
     else
+      @datasets = CsvDataset.order('created_at DESC')
       render('index')
     end
   end

--- a/app/models/csv_dataset.rb
+++ b/app/models/csv_dataset.rb
@@ -4,6 +4,9 @@ class CsvDataset < ActiveRecord::Base
   belongs_to :project
   belongs_to :user
   has_one :import_job, :dependent => :destroy
+  validates_attachment_presence :csv_file
+  validates_attachment_size :csv_file, :greater_than => 0.bytes, :unless => Proc.new { |imports| imports.csv_file_file_name.blank? }
+  validates_attachment_content_type :csv_file, :content_type => 'text/csv'
 
   def status
     return 'new' if import_job.nil?


### PR DESCRIPTION
Uses paperclip's built-in validators for content type and presence.  Content type is limited to text/csv.

Fixes #16 
