### PR TITLE
Improve handling of CSV files from Excel that are not exactly UTF-8

### DIFF
--- a/app/models/csv_dataset.rb
+++ b/app/models/csv_dataset.rb
@@ -1,5 +1,6 @@
 class CsvDataset < ActiveRecord::Base
   attr_accessible :csv_file
+  attr_accessible :encoding
   has_attached_file :csv_file
   belongs_to :project
   belongs_to :user

--- a/db/migrate/20131010153245_add_encoding_to_csv_datasets.rb
+++ b/db/migrate/20131010153245_add_encoding_to_csv_datasets.rb
@@ -1,0 +1,5 @@
+class AddEncodingToCsvDatasets < ActiveRecord::Migration
+  def change
+    add_column :csv_datasets, :encoding, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130925132733) do
+ActiveRecord::Schema.define(version: 20131010153245) do
 
   create_table "categorical_trait_categories", force: true do |t|
     t.string   "name"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20130925132733) do
     t.integer  "user_id"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
+    t.string   "encoding"
   end
 
   add_index "csv_datasets", ["user_id"], name: "index_csv_datasets_on_user_id", using: :btree

--- a/lib/traitdb_import/validator.rb
+++ b/lib/traitdb_import/validator.rb
@@ -21,9 +21,10 @@ module TraitDB
     attr_reader :datasets, :trait_headers
     # The template specifies what columns are valid
     # If we see a magic value in here it needs to be moved to the template
-    def initialize(template=nil, path=nil)
+    def initialize(template=nil, path=nil, encoding=nil)
       @config = template
       @filepath = path
+      @encoding = encoding
       @validation_results = {:issues => [], :info => []}
       @parse_results = {:issues => [], :info => []}
       # initial empty collections
@@ -73,6 +74,7 @@ module TraitDB
     def read_csv_file
       @csvfile = CSV.read(@filepath,
                           :headers => true,
+                          :encoding => @encoding,
                           :header_converters => lambda{|f| f ? f.strip : nil},
                           :converters => lambda{|f| f ? f.strip : nil}
       )


### PR DESCRIPTION
If CSV files are not UTF-8, try to read as ISO-8859-1
Fixes issues with CSV files saved by excel.
Adds an encoding property to the CSV dataset and the validator
