### PR TITLE
Replace joins with includes in OTUs controller

### DIFF
--- a/app/controllers/otus_controller.rb
+++ b/app/controllers/otus_controller.rb
@@ -21,8 +21,9 @@ class OtusController < ApplicationController
     else
       @count = 20
     end
-    @total = @project.otus.joins(:taxa).where(where_options).count
-    @otus = @project.otus.joins(:taxa).where(where_options).limit(@count).offset(@start)
+    
+    @total = @project.otus.includes(:csv_dataset).includes(:taxa).where(where_options).count
+    @otus = @project.otus.includes(:csv_dataset).includes(:taxa).where(where_options).limit(@count).offset(@start)
 
   end
 


### PR DESCRIPTION
joins resulted in an OTU listing for each taxon in the OTUs hierarchy.
includes is what I needed - to prefetch related objects.

Fixes #94 
