### PR TITLE
Allow summarization methods to be chosen by YAML config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       less (~> 2.3.1)
     less-rails-bootstrap (2.3.3)
       less-rails (~> 2.3.1)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -79,12 +79,12 @@ class SearchController < ApplicationController
 
     # Output columns should include chosen continuous traits
     @results[:columns][:continuous_traits] = @project.continuous_traits.where(:id => @continuous_trait_predicate_map.keys).map do |continuous_trait|
-      {:id => continuous_trait.id, :name => continuous_trait.full_name, :summarization_method => continuous_trait.summarization_method }
+      {:id => continuous_trait.id, :name => continuous_trait.full_name, :summarization_method => continuous_trait.summarization_method.to_sym }
     end
 
     # output columns should include chosen categorical traits
     @results[:columns][:categorical_traits] = @project.categorical_traits.where(:id => @categorical_trait_category_map.keys).map do |categorical_trait|
-      {:id => categorical_trait.id, :name => categorical_trait.full_name, :summarization_method => categorical_trait.summarization_method }
+      {:id => categorical_trait.id, :name => categorical_trait.full_name, :summarization_method => categorical_trait.summarization_method.to_sym }
     end
 
     # Arrays to hold ids of the traits where notes were recorded

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -448,14 +448,14 @@ class SearchController < ApplicationController
       summarized[:uploader_email] = row_hash_chunk.map{|k,v| v[:uploader_email]}.uniq.join(',')
       summarized[:upload_date] = row_hash_chunk.map{|k,v| v[:upload_date]}.max
       categorical_chunk = row_hash_chunk.map{|k,v| v[:categorical]}.compact
-      categorical_trait_ids = @results[:columns][:categorical_traits].map{|x| x[:id], x[:summarization_method]}
+      categorical_trait_ids = @results[:columns][:categorical_traits].map{|x| [x[:id], x[:summarization_method]]}
       summarized[:categorical] = {}
       categorical_trait_ids.each do |trait_id, summarization_method|
         summarized[:categorical].merge!(categorical_chunk.merge_trait_hashes(trait_id, summarization_method))
       end
       continuous_chunk = row_hash_chunk.map{|k,v| v[:continuous]}.compact
       # Need to get the continuous trait ids
-      continuous_trait_ids = @results[:columns][:continuous_traits].map{|x| x[:id], x[:summarization_method]}
+      continuous_trait_ids = @results[:columns][:continuous_traits].map{|x| [x[:id], x[:summarization_method]]}
       summarized[:continuous] = {}
       continuous_trait_ids.each do |trait_id, summarization_method|
         summarized[:continuous].merge!(continuous_chunk.merge_trait_hashes(trait_id, summarization_method))

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -79,12 +79,12 @@ class SearchController < ApplicationController
 
     # Output columns should include chosen continuous traits
     @results[:columns][:continuous_traits] = @project.continuous_traits.where(:id => @continuous_trait_predicate_map.keys).map do |continuous_trait|
-      {:id => continuous_trait.id, :name => continuous_trait.full_name}
+      {:id => continuous_trait.id, :name => continuous_trait.full_name, :summarization_method => continuous_trait.summarization_method }
     end
 
     # output columns should include chosen categorical traits
     @results[:columns][:categorical_traits] = @project.categorical_traits.where(:id => @categorical_trait_category_map.keys).map do |categorical_trait|
-      {:id => categorical_trait.id, :name => categorical_trait.full_name}
+      {:id => categorical_trait.id, :name => categorical_trait.full_name, :summarization_method => categorical_trait.summarization_method }
     end
 
     # Arrays to hold ids of the traits where notes were recorded
@@ -433,6 +433,10 @@ class SearchController < ApplicationController
   def summarize_results(rows)
     # Chunk rows on summary_taxon.  rows is a hash of otu_ids to hashes of result data
     # summary_taxon is in the hash of result data
+    #
+    # Note on "chunk":
+    # chunk partitions an array (or other enumerable) based on the return value of the block, which is the summary
+    # taxon. In other words - group the rows together that have the same summary taxon and map them through the below block
     summarized_rows = rows.chunk{|otu_id,row_hash| row_hash[:summary_taxon]}.map do |summary_taxon,chunk|
       # For now let's just take the first one
       # Each chunk is an array.  First element is the chunk summary_taxon_id and the second element is
@@ -444,17 +448,17 @@ class SearchController < ApplicationController
       summarized[:uploader_email] = row_hash_chunk.map{|k,v| v[:uploader_email]}.uniq.join(',')
       summarized[:upload_date] = row_hash_chunk.map{|k,v| v[:upload_date]}.max
       categorical_chunk = row_hash_chunk.map{|k,v| v[:categorical]}.compact
-      categorical_trait_ids = @results[:columns][:categorical_traits].map{|x| x[:id]}
+      categorical_trait_ids = @results[:columns][:categorical_traits].map{|x| x[:id], x[:summarization_method]}
       summarized[:categorical] = {}
-      categorical_trait_ids.each do |trait_id|
-        summarized[:categorical].merge!(categorical_chunk.merge_trait_hashes(trait_id, :collect))
+      categorical_trait_ids.each do |trait_id, summarization_method|
+        summarized[:categorical].merge!(categorical_chunk.merge_trait_hashes(trait_id, summarization_method))
       end
       continuous_chunk = row_hash_chunk.map{|k,v| v[:continuous]}.compact
       # Need to get the continuous trait ids
-      continuous_trait_ids = @results[:columns][:continuous_traits].map{|x| x[:id]}
+      continuous_trait_ids = @results[:columns][:continuous_traits].map{|x| x[:id], x[:summarization_method]}
       summarized[:continuous] = {}
-      continuous_trait_ids.each do |trait_id|
-        summarized[:continuous].merge!(continuous_chunk.merge_trait_hashes(trait_id, :avg))
+      continuous_trait_ids.each do |trait_id, summarization_method|
+        summarized[:continuous].merge!(continuous_chunk.merge_trait_hashes(trait_id, summarization_method))
       end
       # Taxonomy can be reconstituted by chopping off things after the summary taxon
       summarized[:metadata] = row_hash_chunk.map{|k,v| v[:metadata]}.compact.inject do |memo, metadata|

--- a/app/models/categorical_trait.rb
+++ b/app/models/categorical_trait.rb
@@ -8,7 +8,4 @@ class CategoricalTrait < ActiveRecord::Base
     categorical_trait_categories.pluck(:name)
   end
 
-  def summarization_method
-    :collect
-  end
 end

--- a/app/models/categorical_trait.rb
+++ b/app/models/categorical_trait.rb
@@ -7,4 +7,8 @@ class CategoricalTrait < ActiveRecord::Base
   def category_names
     categorical_trait_categories.pluck(:name)
   end
+
+  def summarization_method
+    :collect
+  end
 end

--- a/app/models/continuous_trait.rb
+++ b/app/models/continuous_trait.rb
@@ -11,4 +11,8 @@ class ContinuousTrait < ActiveRecord::Base
       'Default'
     end
   end
+
+  def summarization_method
+    :avg
+  end
 end

--- a/app/models/continuous_trait.rb
+++ b/app/models/continuous_trait.rb
@@ -11,8 +11,4 @@ class ContinuousTrait < ActiveRecord::Base
       'Default'
     end
   end
-
-  def summarization_method
-    :avg
-  end
 end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -275,6 +275,9 @@ class ImportJob < ActiveRecord::Base
         if import_trait[:format]
           trait.display_format = DisplayFormat.where(:name => import_trait[:format]).first
         end
+        if import_trait[:summarization_method]
+          trait.summarization_method = import_trait[:summarization_method]
+        end
       end
 
       # Find or create a trait set for each level and the last delimiter becomes the name of the trait
@@ -304,6 +307,9 @@ class ImportJob < ActiveRecord::Base
         trait.project = project
         if import_trait[:format]
           trait.display_format = DisplayFormat.where(:name => import_trait[:format]).first
+        end
+        if import_trait[:summarization_method]
+          trait.summarization_method = import_trait[:summarization_method]
         end
       end
 

--- a/app/models/trait_common.rb
+++ b/app/models/trait_common.rb
@@ -1,7 +1,7 @@
 module TraitCommon
   extend ActiveSupport::Concern
   included do
-    attr_accessible :name, :display_format_id
+    attr_accessible :name, :display_format_id, :summarization_method
     belongs_to :project
     belongs_to :import_job
     has_one :csv_dataset, :through => :import_job

--- a/app/views/search/results.csv.erb
+++ b/app/views/search/results.csv.erb
@@ -5,7 +5,12 @@
     headers << "Upload Date"
   end
   @results[:columns][:categorical_traits].each do |trait|
-    headers << trait[:name]
+    if params['summarize_results']
+      # If summarizing, put the summarization method in the column name
+      headers << "#{trait[:name]} #{trait[:summarization_method]}"
+    else
+      headers << trait[:name]
+    end
     if @results[:columns][:categorical_trait_notes_ids].include? trait[:id]
       headers << "Notes: #{trait[:name]}"
     end
@@ -14,7 +19,12 @@
     end
   end
   @results[:columns][:continuous_traits].each do |trait|
-    headers << trait[:name]
+    if params['summarize_results']
+      # If summarizing, put the summarization method in the column name
+      headers << "#{trait[:name]} #{trait[:summarization_method]}"
+    else
+      headers << trait[:name]
+    end
     if @results[:columns][:continuous_trait_notes_ids].include? trait[:id]
       headers << "Notes: #{trait[:name]}"
     end

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -25,7 +25,7 @@
               <% col_count += 1 -%>
             <% end %>
             <% @results[:columns][:categorical_traits].each do |trait| %>
-              <th><%= trait[:name] %></th>
+              <th><%= trait[:name] %><% if params['summarize_results']%> (<%= trait[:summarization_method].to_s %>) <% end %></th>
               <% col_count += 1 -%>
               <% if @results[:columns][:categorical_trait_notes_ids].include? trait[:id] %>
                 <th>Notes: <%= trait[:name] %></th>
@@ -33,7 +33,7 @@
               <% end %>
             <% end %>
             <% @results[:columns][:continuous_traits].each do |trait| %>
-              <th><%= trait[:name] %></th>
+              <th><%= trait[:name] %><% if params['summarize_results']%> (<%= trait[:summarization_method].to_s %>) <% end %></th>
               <% col_count += 1 -%>
               <% if @results[:columns][:continuous_trait_notes_ids].include? trait[:id] %>
                 <th>Notes: <%= trait[:name] %></th>

--- a/db/migrate/20150113155832_add_summarization_method_to_trait.rb
+++ b/db/migrate/20150113155832_add_summarization_method_to_trait.rb
@@ -1,0 +1,6 @@
+class AddSummarizationMethodToTrait < ActiveRecord::Migration
+  def change
+    add_column :categorical_traits, :summarization_method, :string, :default => 'collect'
+    add_column :continuous_traits, :summarization_method, :string, :default => 'collect'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141002144445) do
+ActiveRecord::Schema.define(version: 20150113155832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,8 @@ ActiveRecord::Schema.define(version: 20141002144445) do
     t.datetime "updated_at"
     t.integer  "display_format_id"
     t.integer  "trait_set_id"
-    t.integer  "project_id",        default: 1, null: false
+    t.integer  "project_id",           default: 1,         null: false
+    t.string   "summarization_method", default: "collect"
   end
 
   add_index "categorical_traits", ["display_format_id"], name: "index_categorical_traits_on_display_format_id", using: :btree
@@ -108,7 +109,8 @@ ActiveRecord::Schema.define(version: 20141002144445) do
     t.datetime "updated_at"
     t.integer  "display_format_id"
     t.integer  "trait_set_id"
-    t.integer  "project_id",        default: 1, null: false
+    t.integer  "project_id",           default: 1,         null: false
+    t.string   "summarization_method", default: "collect"
   end
 
   add_index "continuous_traits", ["display_format_id"], name: "index_continuous_traits_on_display_format_id", using: :btree

--- a/lib/merge_trait_hashes.rb
+++ b/lib/merge_trait_hashes.rb
@@ -10,7 +10,6 @@ class Array
     all_keys = traits_matching_id.map{|x| x[:values]}.flatten.map{|x| x.keys}.flatten
     all_values = traits_matching_id.map{|x| x[:values]}.flatten.map{|x| x.values}.flatten
     merged = select{|x| x[trait_id]}.map{|x| x[trait_id]}.first.deep_dup
-    summarized = nil
     if merged
       case method
         when :avg

--- a/lib/traitdb_import/Sample.yml
+++ b/lib/traitdb_import/Sample.yml
@@ -19,6 +19,7 @@ traitdb_spreadsheet_template:
         - ZO
         - ZW
         - XY
+      summarization_method: "collect"
     -
       name: Hybrid
       values:
@@ -28,6 +29,7 @@ traitdb_spreadsheet_template:
     -
       name: Chromosome Number
       format: integer # formats are only for display
+      summarization_method: "avg"
     -
       name: Avg Mass
       format: float

--- a/lib/traitdb_import/import_template.rb
+++ b/lib/traitdb_import/import_template.rb
@@ -203,6 +203,18 @@ module TraitDB
       t.nil? ? [] : t['format']
     end
 
+    # Summarization method
+    def continuous_trait_summarization_method(trait_name)
+      t = continuous(trait_name)
+      t.nil? ? [] : t['summarization_method']
+    end
+
+    def categorical_trait_summarization_method(trait_name)
+      t = categorical(trait_name)
+      t.nil? ? [] : t['summarization_method']
+    end
+
+
     def column_headers(group_name)
       headers = []
       headers += taxonomy_columns.values

--- a/lib/traitdb_import/validator.rb
+++ b/lib/traitdb_import/validator.rb
@@ -146,7 +146,8 @@ module TraitDB
       @trait_headers[:continuous] += found_headers.map{|x|
         {:name => x,
          :groups => @config.groups_for_continuous_trait(x),
-         :format => @config.continuous_trait_format(x)
+         :format => @config.continuous_trait_format(x),
+         :summarization_method => @config.continuous_trait_summarization_method(x)
         }
       }
       @validation_results[:info] << {:info => "Found #{found_headers.count} continuous trait headers"}
@@ -163,7 +164,8 @@ module TraitDB
         {:name => x,
          :groups => @config.groups_for_categorical_trait(x),
          :format => @config.categorical_trait_format(x),
-         :values => @config.categorical_trait_values(x)
+         :values => @config.categorical_trait_values(x),
+         :summarization_method => @config.categorical_trait_summarization_method(x)
         }
       }
       @validation_results[:info] << {:info => "Found #{found_headers.count} categorical trait headers"}


### PR DESCRIPTION
Summarization methods can now be selected per trait and placed into the YAML file.

Initial summarization rules are avg, first, last, min, max, collect. See [merge_trait_hashes.rb](https://github.com/NESCent/TraitDB/blob/31f1415cfcafa4591f659f419ac16c26a1739a66/lib/merge_trait_hashes.rb) for examples of single value and multi-value summary

Updated the Sample.yml with examples, wiki documentation forthcoming

Fixes #212 