### PR TITLE
Restore delayed_job_active_record gem to standard install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'delayed_job', '~> 4.0.0'
 
 # delayed_job_active_record 4.0.0 has issues with postgres 8.4
 # This version has a workaround
-gem 'delayed_job_active_record', :git => 'https://github.com/panter/delayed_job_active_record.git'
+gem 'delayed_job_active_record', '~> 4.0.0'
 gem "daemons"
 
 # devise for user accounts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/panter/delayed_job_active_record.git
-  revision: 111a122cdc4d5cdae027691ef7c68c5a76470df7
-  specs:
-    delayed_job_active_record (4.0.0)
-      activerecord (>= 3.0)
-      delayed_job (>= 3.0)
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -72,6 +64,9 @@ GEM
     daemons (1.1.9)
     delayed_job (4.0.2)
       activesupport (>= 3.0, < 4.2)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     devise (3.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -244,7 +239,7 @@ DEPENDENCIES
   coveralls
   daemons
   delayed_job (~> 4.0.0)
-  delayed_job_active_record!
+  delayed_job_active_record (~> 4.0.0)
   devise (~> 3.3.0)
   jquery-rails
   jquery-tablesorter (~> 1.12.6)
@@ -265,3 +260,6 @@ DEPENDENCIES
   uglifier (~> 2.5.1)
   webmock (~> 1.17.4)
   wicked
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Previous version was installed from a git fork of the gem, for postgres 8.4 compatibility. 
However, this recently broke the Travis build (see #218)

Changing delayed_job_active_record to use the mainline gem fixes the build. Tests pass with postgres, and I'm not concerned with 8.4 compatibility