### PR TITLE
Update .travis.yml to use ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 # .travis.yml
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1 # 2.1.0 is broken, see https://github.com/travis-ci/travis-ci/issues/2220
+  - 2.2.0
 env:
   - TRAITDB_PG_TEST_USER=postgres TEST_SUITE=units
   - TRAITDB_PG_TEST_USER=postgres TEST_SUITE=functionals


### PR DESCRIPTION
Gemfile had been updated to ruby 2.2.0 but Travis-CI spec was still targeting pre-2.2 versions.