### PR TITLE
Fix bad HTML in app template

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
             </li>
           <% else %>
           <%# Not signed in %>
-            <li><%= link_to("Sign in", new_user_session_path) %>
+            <li><%= link_to("Sign in", new_user_session_path) %></li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
Hi @dleehr, when running the tests via `bundle exec rake test`, I ran into a failure it looked like I could fix. The error was:

```
# Running:

.................E.....ignoring attempt to close li with ul
  opened at byte 1151, line 29
  closed at byte 1200, line 30
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "Sign in</a>\n        </ul>\n      </div>\n "
ignoring attempt to close li with div
  opened at byte 1151, line 29
  closed at byte 1212, line 31
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "        </ul>\n      </div>\n    </div>\n  "
ignoring attempt to close li with div
  opened at byte 1151, line 29
  closed at byte 1223, line 32
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "l>\n      </div>\n    </div>\n  </div>\n  <d"
ignoring attempt to close li with div
  opened at byte 1151, line 29
  closed at byte 1232, line 33
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "</div>\n    </div>\n  </div>\n  <div class="
ignoring attempt to close li with div
  opened at byte 1151, line 29
  closed at byte 1519, line 45
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "net</a></p>\n</div>\n\n</div>\n</body>\n</htm"
ignoring attempt to close li with body
  opened at byte 1151, line 29
  closed at byte 1526, line 46
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "</p>\n</div>\n\n</div>\n</body>\n</html>\n"
ignoring attempt to close li with html
  opened at byte 1151, line 29
  closed at byte 1534, line 47
  attributes at open: {}
  text around open: "a></li>\n            <li><a href=\"/users/"
  text around close: "iv>\n\n</div>\n</body>\n</html>\n"
..DEPRECATED: Use assert_nil if expecting nil from test/unit/taxon_test.rb:13. This will fail in Minitest 6.
```

and it appears to have been caused by the code I've patched here. After this change, the only failing test I get is about a mismatch in PhantomJS versions so it looks like this was the fix.